### PR TITLE
fix EURMW prefix

### DIFF
--- a/data/belux.json
+++ b/data/belux.json
@@ -7292,7 +7292,7 @@
           "frequency":"135.750",
           "type":"CTR",
           "pre":[
-             "EURM"
+             "EURM-W"
           ]
        }
     },


### PR DESCRIPTION
prefix was EURM instead of EURM-W which resulted in the sector not showing while online. Tested it on the beta.