### PR TITLE
8.33 kHz Germany Fix

### DIFF
--- a/data/germany.json
+++ b/data/germany.json
@@ -12713,13 +12713,6 @@
       "callsign": "Bremen Radar"
     },
 
-    "GGC": {
-      "colours": [{ "hex": "#898768" }],
-      "pre": ["EDGG"],
-      "type": "CTR",
-      "frequency": "135.725",
-      "callsign": "Langen Radar"
-    },
     "BAD": {
       "colours": [{ "hex": "#9ebb98" }],
       "pre": ["EDGG"],
@@ -12760,13 +12753,6 @@
       "pre": ["EDGG"],
       "type": "CTR",
       "frequency": "127.725",
-      "callsign": "Langen Radar"
-    },
-    "HMMH": {
-      "colours": [{ "hex": "#8cc64b" }],
-      "pre": ["EDGG"],
-      "type": "CTR",
-      "frequency": "118.750",
       "callsign": "Langen Radar"
     },
     "KIR": {

--- a/data/germany.json
+++ b/data/germany.json
@@ -12653,7 +12653,7 @@
       "colours": [{ "hex": "#d3c481" }],
       "pre": ["EDWW"],
       "type": "CTR",
-      "frequency": "128.750",
+      "frequency": "128.760",
       "callsign": "Bremen Radar"
     },
     "EIDE": {
@@ -12688,14 +12688,14 @@
       "colours": [{ "hex": "#53d1d8" }],
       "pre": ["EDWW"],
       "type": "CTR",
-      "frequency": "125.850",
+      "frequency": "125.855",
       "callsign": "Bremen Radar"
     },
     "HRZ": {
       "colours": [{ "hex": "#a46c8b" }],
       "pre": ["EDWW"],
       "type": "CTR",
-      "frequency": "126.650",
+      "frequency": "126.655",
       "callsign": "Bremen Radar"
     },
     "MAR": {
@@ -12731,14 +12731,14 @@
       "colours": [{ "hex": "#ce0f8f" }],
       "pre": ["EDGG"],
       "type": "CTR",
-      "frequency": "124.425",
+      "frequency": "124.430",
       "callsign": "Langen Radar"
     },
     "GIN": {
       "colours": [{ "hex": "#8b26aa" }],
       "pre": ["EDGG"],
       "type": "CTR",
-      "frequency": "124.725",
+      "frequency": "124.730",
       "callsign": "Langen Radar"
     },
     "HAB": {
@@ -12759,21 +12759,21 @@
       "colours": [{ "hex": "#510d8b" }],
       "pre": ["EDGG"],
       "type": "CTR",
-      "frequency": "128.525",
+      "frequency": "133.460",
       "callsign": "Langen Radar"
     },
     "KNG": {
       "colours": [{ "hex": "#1270BC" }],
       "pre": ["EDGG"],
       "type": "CTR",
-      "frequency": "125.675",
+      "frequency": "125.680",
       "callsign": "Langen Radar"
     },
     "KTG": {
       "colours": [{ "hex": "#678953" }],
       "pre": ["EDGG"],
       "type": "CTR",
-      "frequency": "123.275",
+      "frequency": "123.280",
       "callsign": "Langen Radar"
     },
     "LBU": {
@@ -12787,7 +12787,7 @@
       "colours": [{ "hex": "#22de14" }],
       "pre": ["EDGG"],
       "type": "CTR",
-      "frequency": "132.150",
+      "frequency": "132.155",
       "callsign": "Langen Radar"
     },
     "NKRH": {
@@ -12808,7 +12808,7 @@
       "colours": [{ "hex": "#52d360" }],
       "pre": ["EDGG"],
       "type": "CTR",
-      "frequency": "125.400",
+      "frequency": "125.405",
       "callsign": "Langen Radar"
     },
     "RUD": {
@@ -12837,112 +12837,112 @@
       "colours": [{ "hex": "#cebab8" }],
       "pre": ["EDUU"],
       "type": "CTR",
-      "frequency": "127.300",
+      "frequency": "132.140",
       "callsign": "Rhein Radar"
     },
     "CHI": {
       "colours": [{ "hex": "#caf719" }],
       "pre": ["EDUU"],
       "type": "CTR",
-      "frequency": "128.825",
+      "frequency": "123.390",
       "callsign": "Rhein Radar"
     },
     "DON": {
       "colours": [{ "hex": "#059319" }],
       "pre": ["EDUU"],
       "type": "CTR",
-      "frequency": "123.725",
+      "frequency": "132.730",
       "callsign": "Rhein Radar"
     },
     "ERL": {
       "colours": [{ "hex": "#950458" }],
       "pre": ["EDUU"],
       "type": "CTR",
-      "frequency": "136.400",
+      "frequency": "136.405",
       "callsign": "Rhein Radar"
     },
     "FFM": {
       "colours": [{ "hex": "#06895d" }],
       "pre": ["EDUU"],
       "type": "CTR",
-      "frequency": "132.325",
+      "frequency": "132.330",
       "callsign": "Rhein Radar"
     },
     "FUL": {
       "colours": [{ "hex": "#e79d14" }],
       "pre": ["EDUU"],
       "type": "CTR",
-      "frequency": "136.325",
+      "frequency": "133.655",
       "callsign": "Rhein Radar"
     },
     "HVL": {
       "colours": [{ "hex": "#e212c5" }],
       "pre": ["EDUU"],
       "type": "CTR",
-      "frequency": "133.750",
+      "frequency": "128.235",
       "callsign": "Rhein Radar"
     },
     "ISA": {
       "colours": [{ "hex": "#c5f8ca" }],
       "pre": ["EDUU"],
       "type": "CTR",
-      "frequency": "136.350",
+      "frequency": "136.335",
       "callsign": "Rhein Radar"
     },
     "NTM": {
       "colours": [{ "hex": "#638c09" }],
       "pre": ["EDUU"],
       "type": "CTR",
-      "frequency": "136.475",
+      "frequency": "132.080",
       "callsign": "Rhein Radar"
     },
     "OSE": {
       "colours": [{ "hex": "#a24fde" }],
       "pre": ["EDUU"],
       "type": "CTR",
-      "frequency": "133.025",
+      "frequency": "133.035",
       "callsign": "Rhein Radar"
     },
     "OH2": {
       "colours": [{ "hex": "#f43e36" }],
       "pre": ["EDUU"],
       "type": "CTR",
-      "frequency": "126.775",
+      "frequency": "126.785",
       "callsign": "Rhein Radar"
     },
     "SAL": {
       "colours": [{ "hex": "#7f56b0" }],
       "pre": ["EDUU"],
       "type": "CTR",
-      "frequency": "122.625",
+      "frequency": "133.860",
       "callsign": "Rhein Radar"
     },
     "SLN": {
       "colours": [{ "hex": "#bad4d7" }],
       "pre": ["EDUU"],
       "type": "CTR",
-      "frequency": "120.925",
+      "frequency": "120.930",
       "callsign": "Rhein Radar"
     },
     "SPE": {
       "colours": [{ "hex": "#1583f7" }],
       "pre": ["EDUU"],
       "type": "CTR",
-      "frequency": "128.075",
+      "frequency": "133.285",
       "callsign": "Rhein Radar"
     },
     "TGO": {
       "colours": [{ "hex": "#b418f0" }],
       "pre": ["EDUU"],
       "type": "CTR",
-      "frequency": "132.400",
+      "frequency": "132.405",
       "callsign": "Rhein Radar"
     },
     "WUR": {
       "colours": [{ "hex": "#714d2a" }],
       "pre": ["EDUU"],
       "type": "CTR",
-      "frequency": "134.075",
+      "frequency": "134.085",
       "callsign": "Rhein Radar"
     },
 
@@ -12950,63 +12950,63 @@
       "colours": [{ "hex": "#cbef87" }],
       "pre": ["EDYY"],
       "type": "CTR",
-      "frequency": "133.950",
+      "frequency": "133.955",
       "callsign": "Maastricht Radar"
     },
     "CELH": {
       "colours": [{ "hex": "#bebc35" }],
       "pre": ["EDYY"],
       "type": "CTR",
-      "frequency": "128.775",
+      "frequency": "128.810",
       "callsign": "Maastricht Radar"
     },
     "HOL": {
       "colours": [{ "hex": "#e0377f" }],
       "pre": ["EDYY"],
       "type": "CTR",
-      "frequency": "120.950",
+      "frequency": "120.860",
       "callsign": "Maastricht Radar"
     },
     "JEV": {
       "colours": [{ "hex": "#d514ad" }],
       "pre": ["EDYY"],
       "type": "CTR",
-      "frequency": "134.700",
+      "frequency": "136.465",
       "callsign": "Maastricht Radar"
     },
     "JEVH": {
       "colours": [{ "hex": "#ff2f6d" }],
       "pre": ["EDYY"],
       "type": "CTR",
-      "frequency": "132.800",
+      "frequency": "129.735",
       "callsign": "Maastricht Radar"
     },
     "MNS": {
       "colours": [{ "hex": "#67d78e" }],
       "pre": ["EDYY"],
       "type": "CTR",
-      "frequency": "133.850",
+      "frequency": "122.185",
       "callsign": "Maastricht Radar"
     },
     "RHR": {
       "colours": [{ "hex": "#cf75aa" }],
       "pre": ["EDYY"],
       "type": "CTR",
-      "frequency": "132.625",
+      "frequency": "124.435",
       "callsign": "Maastricht Radar"
     },
     "SOL": {
       "colours": [{ "hex": "#1357b1" }],
       "pre": ["EDYY"],
       "type": "CTR",
-      "frequency": "131.375",
+      "frequency": "134.710",
       "callsign": "Maastricht Radar"
     },
     "SOLH": {
       "colours": [{ "hex": "#810958" }],
       "pre": ["EDYY"],
       "type": "CTR",
-      "frequency": "134.725",
+      "frequency": "131.380",
       "callsign": "Maastricht Radar"
     },
 
@@ -13091,7 +13091,7 @@
       "colours": [{ "hex": "#43563b" }],
       "pre": ["EDDP"],
       "type": "APP",
-      "frequency": "126.075",
+      "frequency": "126.065",
       "callsign": "München Radar"
     },
     "DPSAT": {
@@ -13127,7 +13127,7 @@
       "colours": [{ "hex": "#d5e57d" }],
       "pre": ["EDDB"],
       "type": "APP",
-      "frequency": "119.625",
+      "frequency": "119.630",
       "callsign": "Bremen Radar"
     },
     "DBAS": {
@@ -13141,42 +13141,42 @@
       "colours": [{ "hex": "#45295f" }],
       "pre": ["EDDB"],
       "type": "APP",
-      "frequency": "136.100",
+      "frequency": "136.105",
       "callsign": "Berlin Director"
     },
     "DBU": {
       "colours": [{ "hex": "#8cd620" }],
       "pre": ["EDDB"],
       "type": "APP",
-      "frequency": "121.125",
+      "frequency": "121.130",
       "callsign": "Berlin Director"
     },
     "DBDN": {
       "colours": [{ "hex": "#5cb9a2" }],
       "pre": ["EDDB"],
       "type": "DEP",
-      "frequency": "134.425",
+      "frequency": "134.430",
       "callsign": "Bremen Radar"
     },
     "DBDS": {
       "colours": [{ "hex": "#bdc3f9" }],
       "pre": ["EDDB"],
       "type": "DEP",
-      "frequency": "120.625",
+      "frequency": "120.630",
       "callsign": "Bremen Radar"
     },
     "DHF": {
       "colours": [{ "hex": "#7626d3" }],
       "pre": ["EDDH"],
       "type": "APP",
-      "frequency": "118.200",
+      "frequency": "118.205",
       "callsign": "Hamburg Director"
     },
     "DVF": {
       "colours": [{ "hex": "#5c124a" }],
       "pre": ["EDDV"],
       "type": "APP",
-      "frequency": "119.600",
+      "frequency": "119.605",
       "callsign": "Hannover Director"
     },
     "DWF": {
@@ -13197,28 +13197,28 @@
       "colours": [{ "hex": "#6d3049" }],
       "pre": ["EDDH"],
       "type": "APP",
-      "frequency": "119.525",
+      "frequency": "119.510",
       "callsign": "Bremen Radar"
     },
     "HAMW": {
       "colours": [{ "hex": "#33c6c6" }],
       "pre": ["EDDH"],
       "type": "APP",
-      "frequency": "134.250",
+      "frequency": "134.255",
       "callsign": "Bremen Radar"
     },
     "HAN": {
       "colours": [{ "hex": "#77087c" }],
       "pre": ["EDDV"],
       "type": "APP",
-      "frequency": "131.325",
+      "frequency": "119.490",
       "callsign": "Bremen Radar"
     },
     "TMNA": {
       "colours": [{ "hex": "#589773" }],
       "pre": ["ETMN"],
       "type": "APP",
-      "frequency": "123.300",
+      "frequency": "129.855",
       "callsign": "Nordholz Radar"
     },
     "TNTA": {
@@ -13232,7 +13232,7 @@
       "colours": [{ "hex": "#7bcc2a" }],
       "pre": ["ETSH"],
       "type": "APP",
-      "frequency": "129.850",
+      "frequency": "129.855",
       "callsign": "Holzdorf Radar"
     },
 


### PR DESCRIPTION
- fixes some missing 8.33 frequencies
- removes stations GGC and HMMH, which have been removed.