### PR TITLE
li: fix broken structure

### DIFF
--- a/data/li.json
+++ b/data/li.json
@@ -10885,26 +10885,26 @@
         "type": "CTR",
         "pre": ["LIUP"],
         "colours": [{ "hex": "#005200" }]
-      },
-    "callsigns": {
-      "DEL":{
-        "":"Delivery",
-        "P":"Planner"
-     },
-     "GND":{
-        "":"Ground",
-        "P":"Planner"
-     },
-     "TWR":{
-        "":"Tower",
-        "I":"Information"
-     },
-     "APP":{
-        "":"Approach",
-        "F":"Final"
-     }
+      }
+  },
+  "callsigns": {
+    "DEL":{
+      "":"Delivery",
+      "P":"Planner"
+    },
+    "GND":{
+      "":"Ground",
+      "P":"Planner"
+    },
+    "TWR":{
+      "":"Tower",
+      "I":"Information"
+    },
+    "APP":{
+      "":"Approach",
+      "F":"Final"
     }
-   },
+  },
   "airports": {
       "LIAA": {
         "callsign": "Terni - Alvaro Leonardi",


### PR DESCRIPTION
`callsigns` were a child of `positions` instead of a sibling