### PR TITLE
[HK] Fix erroneous ownership for Hong Kong Departure High

### DIFF
--- a/data/vh-vm.json
+++ b/data/vh-vm.json
@@ -976,7 +976,7 @@
               "DEP",
               "APP",
               "FAD",
-              "TRE",
+              "TRW",
               "PAR"
           ],
           "sectors": [


### PR DESCRIPTION
I forgot to change the ownership priority for H_DEP when doing 2404 -_-