### PR TITLE
updated RHR frequency

### DIFF
--- a/data/ed.json
+++ b/data/ed.json
@@ -13448,7 +13448,7 @@
       "colours": [{ "hex": "#cf75aa" }],
       "pre": ["EDYY"],
       "type": "CTR",
-      "frequency": "124.435",
+      "frequency": "128.790",
       "callsign": "Maastricht Radar"
     },
     "SOL": {


### PR DESCRIPTION
coverage by RHR was not showing on VATGlasses due to changed frequency which was not updated in the VATGlasses data; this PR fixes this issue