### PR TITLE
EDGG AIRAC2413v2

### DIFF
--- a/data/ed.json
+++ b/data/ed.json
@@ -8997,6 +8997,7 @@
       "group": "EDYY",
       "uid": "MH",
       "owner": [
+      	"MM",
         "MH",
         "RH",
 	"ML",
@@ -9057,6 +9058,7 @@
       "group": "EDYY",
       "uid": "ML",
       "owner": [
+      	"MM",
         "ML",
         "MH",
 	"RL",
@@ -13359,6 +13361,13 @@
       "pre": ["EDYY"],
       "type": "CTR",
       "frequency": "129.840",
+      "callsign": "Maastricht Radar"
+    },
+    "MM": {
+      "colours": [{ "hex": "#a3062d" }],
+      "pre": ["EDYY"],
+      "type": "CTR",
+      "frequency": "130.110",
       "callsign": "Maastricht Radar"
     },
     "ML": {

--- a/data/ed.json
+++ b/data/ed.json
@@ -3515,10 +3515,10 @@
       ]
     },
     {
-      "id": "Bottrop (Düsseldorf North)",
-      "group": "APP",
+      "id": "Bottrop",
+      "group": "EDGG",
       "uid": "BOT",
-      "owner": ["BOT", "DLD", "DLA", "DLF", "PADH"],
+      "owner": ["BOT", "DLD", "DLA", "DLAT", "PADH"],
       "sectors": [
         {
           "max": 244,
@@ -3750,9 +3750,9 @@
     },
     {
       "id": "Köln",
-      "group": "APP",
+      "group": "EDGG",
       "uid": "DKA",
-      "owner": ["DKA", "DKF", "NOR", "PADH"],
+      "owner": ["DKA", "DKAT", "NOR", "PADH"],
       "sectors": [
         {
           "max": 144,
@@ -3890,97 +3890,67 @@
           "max": 84,
           "min": 0,
           "points": [
-            ["495852", "0101746"],
-            ["495630", "0101749"],
-            ["495630", "0101749"],
-            ["495000", "0101800"],
-            ["495000", "0101800"],
-            ["494040", "0101816"],
-            ["494040", "0101816"],
-            ["493820", "0101820"],
-            ["493820", "0101820"],
-            ["491920", "0102220"],
-            ["491920", "0102220"],
-            ["491907", "0100738"],
-            ["491907", "0100738"],
-            ["491604", "0095033"],
-            ["491604", "0095033"],
-            ["491722", "0093921"],
-            ["491722", "0093921"],
-            ["491620", "0092710"],
-            ["491620", "0092710"],
-            ["493402", "0094113"],
-            ["493402", "0094113"],
-            ["494332", "0093424"],
-            ["494332", "0093424"],
-            ["494455", "0094017"],
-            ["494455", "0094017"],
-            ["494645", "0094152"],
-            ["494645", "0094152"],
-            ["495527", "0094217"],
-            ["495527", "0094217"],
-            ["495839", "0094133"],
-            ["495839", "0094133"],
-            ["495841", "0094528"],
-            ["495841", "0094528"],
-            ["495852", "0101746"]
+			["495852", "0101746"],
+			["495630", "0101749"],
+			["495000", "0101800"],
+			["494040", "0101816"],
+			["493820", "0101820"],
+			["491920", "0102220"],
+			["491907", "0100738"],
+			["491604", "0095033"],
+			["491722", "0093921"],
+			["491620", "0092710"],
+			["492657", "0093535"],
+			["493640", "0093249"],
+			["494245", "0093105"],
+			["494332", "0093424"],
+			["494455", "0094017"],
+			["494645", "0094152"],
+			["495527", "0094217"],
+			["495839", "0094133"],
+			["495841", "0094528"],
+			["495852", "0101746"]
           ]
         },
         {
           "max": 244,
           "min": 105,
           "points": [
-            ["491920", "0102220"],
-            ["491043", "0103516"],
-            ["491043", "0103516"],
-            ["490640", "0102845"],
-            ["490640", "0102845"],
-            ["490102", "0101527"],
-            ["490102", "0101527"],
-            ["485655", "0100549"],
-            ["485655", "0100549"],
-            ["490323", "0095347"],
-            ["490323", "0095347"],
-            ["490700", "0094700"],
-            ["490700", "0094700"],
-            ["491620", "0092710"],
-            ["491620", "0092710"],
-            ["491722", "0093921"],
-            ["491722", "0093921"],
-            ["491604", "0095033"],
-            ["491604", "0095033"],
-            ["491907", "0100738"],
-            ["491907", "0100738"],
-            ["491920", "0102220"]
+			["491920", "0102220"],
+			["491043", "0103516"],
+			["490640", "0102845"],
+			["490102", "0101527"],
+			["485655", "0100549"],
+			["490323", "0095347"],
+			["490700", "0094700"],
+			["491620", "0092710"],
+			["491722", "0093921"],
+			["491604", "0095033"],
+			["491907", "0100738"],
+			["491920", "0102220"]
           ]
         },
         {
           "max": 244,
           "min": 85,
           "points": [
-            ["493815", "0094435"],
-            ["493323", "0095422"],
-            ["493323", "0095422"],
-            ["491920", "0102220"],
-            ["491920", "0102220"],
-            ["491907", "0100738"],
-            ["491907", "0100738"],
-            ["491604", "0095033"],
-            ["491604", "0095033"],
-            ["491722", "0093921"],
-            ["491722", "0093921"],
-            ["491620", "0092710"],
-            ["491620", "0092710"],
-            ["493402", "0094113"],
-            ["493402", "0094113"],
-            ["493815", "0094435"]
+			["493815", "0094435"],
+			["493323", "0095422"],
+			["491920", "0102220"],
+			["491907", "0100738"],
+			["491604", "0095033"],
+			["491722", "0093921"],
+			["491620", "0092710"],
+			["492657", "0093535"],
+			["493240", "0094008"],
+			["493815", "0094435"]
           ]
         }
       ]
     },
     {
-      "id": "Eifel (Frankfurt Hahn)",
-      "group": "APP",
+      "id": "Eifel",
+      "group": "EDGG",
       "uid": "EIF",
       "owner": ["EIF", "RUD", "GIN", "KTG"],
       "sectors": [
@@ -4807,102 +4777,70 @@
           "max": 244,
           "min": 0,
           "points": [
-            ["501730", "0101050"],
-            ["501503", "0101833"],
-            ["501503", "0101833"],
-            ["501337", "0101720"],
-            ["501337", "0101720"],
-            ["500855", "0101728"],
-            ["500855", "0101728"],
-            ["495852", "0101746"],
-            ["495852", "0101746"],
-            ["495841", "0094528"],
-            ["495841", "0094528"],
-            ["495839", "0094133"],
-            ["495839", "0094133"],
-            ["501710", "0093720"],
-            ["501710", "0093720"],
-            ["501732", "0094541"],
-            ["501732", "0094541"],
-            ["501730", "0101050"]
+			["501730", "0101050"],
+			["501503", "0101833"],
+			["501337", "0101720"],
+			["500855", "0101728"],
+			["495852", "0101746"],
+			["495841", "0094528"],
+			["495839", "0094133"],
+			["501710", "0093720"],
+			["501732", "0094541"],
+			["501730", "0101050"]
           ]
         },
         {
           "max": 244,
           "min": 195,
           "points": [
-            ["500031", "0092955"],
-            ["495839", "0094133"],
-            ["495839", "0094133"],
-            ["495841", "0094528"],
-            ["495841", "0094528"],
-            ["495852", "0101746"],
-            ["495852", "0101746"],
-            ["495853", "0102301"],
-            ["495853", "0102301"],
-            ["495630", "0101749"],
-            ["495630", "0101749"],
-            ["494758", "0095927"],
-            ["494758", "0095927"],
-            ["493803", "0095342"],
-            ["493803", "0095342"],
-            ["493323", "0095422"],
-            ["493323", "0095422"],
-            ["493815", "0094435"],
-            ["493815", "0094435"],
-            ["494332", "0093424"],
-            ["494332", "0093424"],
-            ["494520", "0093054"],
-            ["494520", "0093054"],
-            ["495112", "0090728"],
-            ["495112", "0090728"],
-            ["495550", "0090754"],
-            ["495550", "0090754"],
-            ["500004", "0090549"],
-            ["500004", "0090549"],
-            ["500014", "0091439"],
-            ["500014", "0091439"],
-            ["500031", "0092955"]
+			["500031", "0092955"],
+			["495839", "0094133"],
+			["495841", "0094528"],
+			["495852", "0101746"],
+			["495853", "0102301"],
+			["495630", "0101749"],
+			["494758", "0095927"],
+			["493803", "0095342"],
+			["493323", "0095422"],
+			["493815", "0094435"],
+			["493240", "0094008"],
+			["493640", "0093249"],
+			["493921", "0092756"],
+			["494204", "0090638"],
+			["494356", "0090648"],
+			["495112", "0090728"],
+			["495550", "0090754"],
+			["500004", "0090549"],
+			["500014", "0091439"],
+			["500031", "0092955"]
           ]
         },
         {
           "max": 244,
           "min": 135,
           "points": [
-            ["501548", "0091113"],
-            ["501441", "0092624"],
-            ["501441", "0092624"],
-            ["501710", "0093720"],
-            ["501710", "0093720"],
-            ["495839", "0094133"],
-            ["495839", "0094133"],
-            ["500031", "0092955"],
-            ["500031", "0092955"],
-            ["500014", "0091439"],
-            ["500014", "0091439"],
-            ["500004", "0090549"],
-            ["500004", "0090549"],
-            ["501056", "0090241"],
-            ["501056", "0090241"],
-            ["501329", "0090754"],
-            ["501329", "0090754"],
-            ["501548", "0091113"]
+			["501548", "0091113"],
+			["501441", "0092624"],
+			["501710", "0093720"],
+			["495839", "0094133"],
+			["500031", "0092955"],
+			["500014", "0091439"],
+			["500004", "0090549"],
+			["501056", "0090241"],
+			["501329", "0090754"],
+			["501548", "0091113"]
           ]
         },
         {
           "max": 244,
           "min": 135,
           "points": [
-            ["501337", "0101720"],
-            ["500058", "0102824"],
-            ["500058", "0102824"],
-            ["495853", "0102301"],
-            ["495853", "0102301"],
-            ["495852", "0101746"],
-            ["495852", "0101746"],
-            ["500855", "0101728"],
-            ["500855", "0101728"],
-            ["501337", "0101720"]
+			["501337", "0101720"],
+			["500058", "0102824"],
+			["495853", "0102301"],
+			["495852", "0101746"],
+			["500855", "0101728"],
+			["501337", "0101720"]
           ]
         }
       ]
@@ -5164,8 +5102,8 @@
       ]
     },
     {
-      "id": "Hamm (Münster)",
-      "group": "APP",
+      "id": "Hamm",
+      "group": "EDGG",
       "uid": "HMM",
       "owner": ["HMM", "PADH"],
       "sectors": [
@@ -5421,136 +5359,125 @@
           "max": 244,
           "min": 0,
           "points": [
-            ["494520", "0093054"],
-            ["494332", "0093424"],
-            ["494332", "0093424"],
-            ["493402", "0094113"],
-            ["493402", "0094113"],
-            ["491620", "0092710"],
-            ["491620", "0092710"],
-            ["491527", "0091023"],
-            ["491527", "0091023"],
-            ["492630", "0090424"],
-            ["492630", "0090424"],
-            ["493105", "0090503"],
-            ["493105", "0090503"],
-            ["494204", "0090638"],
-            ["494204", "0090638"],
-            ["494356", "0090648"],
-            ["494356", "0090648"],
-            ["494404", "0090803"],
-            ["494404", "0090803"],
-            ["494435", "0091258"],
-            ["494435", "0091258"],
-            ["494445", "0091652"],
-            ["494445", "0091652"],
-            ["494520", "0093054"]
+			["493921", "0092756"],
+			["493640", "0093249"],
+			["492657", "0093535"],
+			["491620", "0092710"],
+			["491527", "0091023"],
+			["492630", "0090424"],
+			["493105", "0090503"],
+			["494204", "0090638"],
+			["493921", "0092756"]
           ]
         },
         {
           "max": 134,
           "min": 0,
           "points": [
-            ["494946", "0091219"],
-            ["494632", "0093215"],
-            ["494632", "0093215"],
-            ["494520", "0093054"],
-            ["494520", "0093054"],
-            ["494445", "0091652"],
-            ["494445", "0091652"],
-            ["494435", "0091258"],
-            ["494435", "0091258"],
-            ["494404", "0090803"],
-            ["494404", "0090803"],
-            ["494608", "0091107"],
-            ["494608", "0091107"],
-            ["494946", "0091219"]
+			["494946", "0091219"],
+			["494632", "0093215"],
+			["494520", "0093054"],
+			["494445", "0091652"],
+			["494435", "0091258"],
+			["494404", "0090803"],
+			["494608", "0091107"],
+			["494946", "0091219"]
+          ]
+        },
+        {
+          "max": 194,
+          "min": 85,
+          "points": [			
+			["494332", "0093424"],
+			["493815", "0094435"],
+			["493240", "0094008"],
+			["493640", "0093249"],
+			["494245", "0093105"],
+			["494332", "0093424"]
           ]
         },
         {
           "max": 244,
           "min": 85,
           "points": [
-            ["494332", "0093424"],
-            ["493815", "0094435"],
-            ["493815", "0094435"],
-            ["493402", "0094113"],
-            ["493402", "0094113"],
-            ["494332", "0093424"]
+			["493640", "0093249"],
+			["493240", "0094008"],
+			["492657", "0093535"],
+			["493640", "0093249"]
           ]
         },
         {
           "max": 174,
           "min": 135,
           "points": [
-            ["495354", "0090225"],
-            ["495112", "0090728"],
-            ["495112", "0090728"],
-            ["494356", "0090648"],
-            ["494356", "0090648"],
-            ["494258", "0085738"],
-            ["494258", "0085738"],
-            ["494836", "0085544"],
-            ["494836", "0085544"],
-            ["495354", "0090225"]
+			["495354", "0090225"],
+			["495112", "0090728"],
+			["494356", "0090648"],
+			["494258", "0085738"],
+			["494836", "0085544"],
+			["495354", "0090225"]
           ]
         },
         {
           "max": 174,
           "min": 0,
           "points": [
-            ["494356", "0090648"],
-            ["494204", "0090638"],
-            ["494204", "0090638"],
-            ["494258", "0085738"],
-            ["494258", "0085738"],
-            ["494356", "0090648"]
+			["494356", "0090648"],
+			["494204", "0090638"],
+			["494258", "0085738"],
+			["494356", "0090648"]
           ]
         },
         {
           "max": 174,
           "min": 0,
           "points": [
-            ["494258", "0085738"],
-            ["494204", "0090638"],
-            ["494204", "0090638"],
-            ["493105", "0090503"],
-            ["493105", "0090503"],
-            ["493435", "0090252"],
-            ["493435", "0090252"],
-            ["494258", "0085738"]
+			["494258", "0085738"],
+			["494204", "0090638"],
+			["493105", "0090503"],
+			["493435", "0090252"],
+			["494258", "0085738"]
           ]
         },
         {
-          "max": 244,
+          "max": 194,
           "min": 135,
           "points": [
-            ["495112", "0090728"],
-            ["494520", "0093054"],
-            ["494520", "0093054"],
-            ["494445", "0091652"],
-            ["494445", "0091652"],
-            ["494435", "0091258"],
-            ["494435", "0091258"],
-            ["494404", "0090803"],
-            ["494404", "0090803"],
-            ["494356", "0090648"],
-            ["494356", "0090648"],
-            ["495112", "0090728"]
+			["495112", "0090728"],
+			["494520", "0093054"],
+			["494445", "0091652"],
+			["494435", "0091258"],
+			["494404", "0090803"],
+			["494356", "0090648"],
+			["495112", "0090728"]
           ]
         },
         {
           "max": 214,
           "min": 0,
-          "points": [
-            ["492630", "0090424"],
-            ["491527", "0091023"],
-            ["491527", "0091023"],
-            ["491507", "0090421"],
-            ["491507", "0090421"],
-            ["491433", "0090244"],
-            ["491433", "0090244"],
-            ["492630", "0090424"]
+          "points": [	
+			["492630", "0090424"],
+			["491527", "0091023"],
+			["491507", "0090421"],
+			["491433", "0090244"],
+			["492630", "0090424"]
+          ]
+        },
+        {
+          "max": 194,
+          "min": 0,
+          "points": [				
+			["494520", "0093054"],
+			["494332", "0093424"],
+			["494245", "0093105"],
+			["493640", "0093249"],
+			["493921", "0092756"],
+			["494204", "0090638"],
+			["494356", "0090648"],
+			["494404", "0090803"],
+			["494435", "0091258"],
+			["494445", "0091652"],
+			["494520", "0093054"]
           ]
         }
       ]
@@ -5737,7 +5664,7 @@
       "id": "Main",
       "group": "EDGG",
       "uid": "MAN",
-      "owner": ["MAIN", "NKRH", "BAD", "DKB", "KTG"],
+      "owner": ["MAN", "NKRH", "BAD", "DKB", "KTG"],
       "sectors": [
         {
           "max": 174,
@@ -5946,8 +5873,8 @@
       ]
     },
     {
-      "id": "Neckar Low (Mannheim)",
-      "group": "APP",
+      "id": "Neckar Low",
+      "group": "EDGG",
       "uid": "NKRL",
       "owner": ["NKRL", "NKRH", "BAD", "DKB", "KTG"],
       "sectors": [
@@ -6018,8 +5945,8 @@
       ]
     },
     {
-      "id": "Nörvenich (Köln Upper)",
-      "group": "APP",
+      "id": "Nörvenich",
+      "group": "EDGG",
       "uid": "NOR",
       "owner": ["NOR", "PADH"],
       "sectors": [
@@ -6779,8 +6706,8 @@
       ]
     },
     {
-      "id": "Paderborn Low (Dortmund)",
-      "group": "APP",
+      "id": "Paderborn Low",
+      "group": "EDGG",
       "uid": "PADL",
       "owner": ["PADL", "HMM", "PADH"],
       "sectors": [
@@ -6917,8 +6844,8 @@
       ]
     },
     {
-      "id": "Pfalz (Saarbrücken)",
-      "group": "APP",
+      "id": "Pfalz",
+      "group": "EDGG",
       "uid": "PFA",
       "owner": ["PFA", "EIF", "RUD", "GIN", "KTG"],
       "sectors": [
@@ -7303,8 +7230,8 @@
       ]
     },
     {
-      "id": "Reutlingen (Stuttgart South)",
-      "group": "APP",
+      "id": "Reutlingen",
+      "group": "EDGG",
       "uid": "REU",
       "owner": ["REU", "STG", "BAD", "DKB", "KTG"],
       "sectors": [
@@ -8378,8 +8305,8 @@
       ]
     },
     {
-      "id": "Stuttgart (North)",
-      "group": "APP",
+      "id": "Stuttgart",
+      "group": "EDGG",
       "uid": "STG",
       "owner": ["STG", "REU", "BAD", "DKB", "KTG"],
       "sectors": [
@@ -9068,18 +8995,19 @@
     {
       "id": "Münster High",
       "group": "EDYY",
-      "uid": "MNSH",
+      "uid": "MH",
       "owner": [
-        "MNS",
-        "RHR",
+        "MH",
+        "RH",
+	"ML",
+	"RL",
         "PADH",
-        "CEL",
-        "SOL",
-        "EMS",
+        "SH",
+        "SL",
+	"YY-BB",
         "DST",
         "EIDW",
-        "WWC",
-        "fss/EUCMW"
+        "WWC"
       ],
       "sectors": [
         {
@@ -9126,18 +9054,19 @@
     {
       "id": "Münster Low",
       "group": "EDYY",
-      "uid": "MNS",
+      "uid": "ML",
       "owner": [
-        "MNS",
-        "RHR",
+        "ML",
+        "MH",
+	"RL",
+	"RH",
         "PADH",
-        "CEL",
-        "SOL",
-        "EMS",
+        "SL",
+        "SH",
+	"YY-BB",
         "DST",
         "EIDW",
-        "WWC",
-        "fss/EUCMW"
+        "WWC"
       ],
       "sectors": [
         {
@@ -9257,8 +9186,14 @@
     {
       "id": "Ruhr High",
       "group": "EDYY",
-      "uid": "RHRH",
-      "owner": ["RHR", "PADH", "fss/EUCMW"],
+      "uid": "RH",
+      "owner": [
+        "RH",
+        "MH",
+	"RL",
+	"ML",
+        "PADH"
+      ],
       "sectors": [
         {
           "min": 355,
@@ -9298,8 +9233,14 @@
     {
       "id": "Ruhr Low",
       "group": "EDYY",
-      "uid": "RHR",
-      "owner": ["RHR", "PADH", "fss/EUCMW"],
+      "uid": "RL",
+      "owner": [
+        "RL",
+        "RH",
+	"LL",
+	"MH",
+        "PADH"
+      ],
       "sectors": [
         {
           "max": 294,
@@ -9419,15 +9360,15 @@
     },
     {
       "id": "Frankfurt North",
-      "group": "APP",
-      "uid": "FAN",
+      "group": "EDGG",
+      "uid": "DFAN",
       "owner": [
-        "FAN",
-        "FFN",
-        "FDN",
-        "FAS",
-        "FFS",
-        "FDS",
+        "DFAN",
+        "DFANT",
+        "DFDN",
+        "DFAS",
+        "DFAST",
+        "DFDS",
         "GIN",
         "RUD",
         "DKB",
@@ -9563,15 +9504,15 @@
     },
     {
       "id": "Frankfurt South",
-      "group": "APP",
-      "uid": "FAS",
+      "group": "EDGG",
+      "uid": "DFAS",
       "owner": [
-        "FAS",
-        "FFS",
-        "FDS",
-        "FAN",
-        "FFN",
-        "FDN",
+        "DFAS",
+        "DFAST",
+        "DFDS",
+        "DFAN",
+        "DFANT",
+        "DFDN",
         "GIN",
         "RUD",
         "DKB",
@@ -9738,9 +9679,9 @@
     },
     {
       "id": "Düsseldorf",
-      "group": "APP",
+      "group": "EDGG",
       "uid": "DLA",
-      "owner": ["DLA", "BOT", "DLD", "DLF", "PADH"],
+      "owner": ["DLA", "BOT", "DLD", "DLAT", "PADH"],
       "sectors": [
         {
           "max": 74,
@@ -12332,8 +12273,19 @@
     {
       "id": "Celle Low",
       "group": "EDYY",
-      "uid": "CEL",
-      "owner": ["CEL", "SOL", "DST", "EIDW", "WWC", "fss/EUCMW"],
+      "uid": "CL",
+      "owner": [
+        "CL",
+        "CH",
+	"SL",
+	"SH",
+        "ML",
+        "MH",
+	"YY-BB",
+        "DST",
+        "EIDW",
+        "WWC"
+      ],
       "sectors": [
         {
           "max": 354,
@@ -12398,16 +12350,18 @@
     {
       "id": "Celle High",
       "group": "EDYY",
-      "uid": "CELH",
+      "uid": "CH",
       "owner": [
-        "CELH",
-        "SOLH",
-        "CEL",
-        "SOL",
+        "CH",
+        "SH",
+	"MH",
+	"CL",
+        "SL",
+        "ML",
+	"YY-BB",
         "DST",
         "EIDW",
-        "WWC",
-        "fss/EUCMW"
+        "WWC"
       ],
       "sectors": [
         {
@@ -12453,7 +12407,7 @@
       "id": "Holstein Low",
       "group": "EDYY",
       "uid": "HL",
-      "owner": ["HL", "HH", "JL", "JH", "BB", "EIDE", "ALR", "EIDW", "WWC", "fss/EUCMW"],
+      "owner": ["HL", "HH", "JL", "JH", "YY-BB", "EIDE", "ALR", "EIDW", "WWC", "fss/EUCMW"],
       "sectors": [
         {
           "max": 364,
@@ -12544,7 +12498,7 @@
 	"JH",
 	"HL",
 	"JL",      
-        "BB",
+        "YY-BB",
         "EIDE",
         "ALR",
         "EIDW",
@@ -12607,7 +12561,7 @@
       "id": "Jever Low",
       "group": "EDYY",
       "uid": "JL",
-      "owner": ["JL", "JH", "HH", "BB", "EIDE", "ALR", "EIDW", "WWC", "fss/EUCMW"],
+      "owner": ["JL", "JH", "HH", "YY-BB", "EIDE", "ALR", "EIDW", "WWC", "fss/EUCMW"],
       "sectors": [
         {
           "max": 364,
@@ -12674,12 +12628,12 @@
     {
       "id": "Jever High",
       "group": "EDYY",
-      "uid": "JEVH",
+      "uid": "JH",
       "owner": [
         "JH",
 	"HH", 
 	"JL",      
-        "BB",      
+        "YY-BB",      
         "EIDE",
         "ALR",
         "EIDW",
@@ -12751,8 +12705,19 @@
     {
       "id": "Solling Low",
       "group": "EDYY",
-      "uid": "SOL",
-      "owner": ["SOL", "CEL", "DST", "EIDW", "WWC", "fss/EUCMW"],
+      "uid": "SL",
+      "owner": [
+        "SL",
+        "SH",
+	"CL",
+	"CH",
+        "ML",
+        "MH",
+	"YY-BB",
+        "DST",
+        "EIDW",
+        "WWC"
+      ],
       "sectors": [
         {
           "max": 354,
@@ -12825,16 +12790,18 @@
     {
       "id": "Solling High",
       "group": "EDYY",
-      "uid": "SOLH",
+      "uid": "SH",
       "owner": [
-        "SOLH",
-        "CELH",
-        "SOL",
-        "CEL",
+        "SL",
+        "CH",
+	"MH",
+	"SL",
+        "CL",
+        "ML",
+	"YY-BB",
         "DST",
         "EIDW",
-        "WWC",
-        "fss/EUCMW"
+        "WWC"
       ],
       "sectors": [
         {
@@ -13180,7 +13147,7 @@
       "frequency": "127.050",
       "callsign": "Langen Radar"
     },
-    "MAIN": {
+    "MAN": {
       "colours": [{ "hex": "#22de14" }],
       "pre": ["EDGG"],
       "type": "CTR",
@@ -13343,14 +13310,14 @@
       "callsign": "Rhein Radar"
     },
 
-    "CEL": {
+    "CL": {
       "colours": [{ "hex": "#cbef87" }],
       "pre": ["EDYY"],
       "type": "CTR",
       "frequency": "133.955",
       "callsign": "Maastricht Radar"
     },
-    "CELH": {
+    "CH": {
       "colours": [{ "hex": "#bebc35" }],
       "pre": ["EDYY"],
       "type": "CTR",
@@ -13385,35 +13352,49 @@
       "frequency": "129.735",
       "callsign": "Maastricht Radar"
     },
-    "BB": {
+    "YY-BB": {
       "colours": [{ "hex": "#bad4d7" }],
       "pre": ["EDYY"],
       "type": "CTR",
       "frequency": "129.840",
       "callsign": "Maastricht Radar"
     },
-    "MNS": {
+    "ML": {
       "colours": [{ "hex": "#67d78e" }],
       "pre": ["EDYY"],
       "type": "CTR",
       "frequency": "122.185",
       "callsign": "Maastricht Radar"
     },
-    "RHR": {
+    "MH": {
+      "colours": [{ "hex": "#909090" }],
+      "pre": ["EDYY"],
+      "type": "CTR",
+      "frequency": "133.215",
+      "callsign": "Maastricht Radar"
+    },
+    "RL": {
       "colours": [{ "hex": "#cf75aa" }],
       "pre": ["EDYY"],
       "type": "CTR",
       "frequency": "128.790",
       "callsign": "Maastricht Radar"
     },
-    "SOL": {
+    "RH": {
+      "colours": [{ "hex": "#646b63" }],
+      "pre": ["EDYY"],
+      "type": "CTR",
+      "frequency": "122.835",
+      "callsign": "Maastricht Radar"
+    },
+    "SL": {
       "colours": [{ "hex": "#1357b1" }],
       "pre": ["EDYY"],
       "type": "CTR",
       "frequency": "134.710",
       "callsign": "Maastricht Radar"
     },
-    "SOLH": {
+    "SH": {
       "colours": [{ "hex": "#810958" }],
       "pre": ["EDYY"],
       "type": "CTR",
@@ -13632,42 +13613,42 @@
       "frequency": "123.600",
       "callsign": "Wittmund Radar"
     },
-    "FAN": {
+    "DFAN": {
       "colours": [{ "hex": "#88623f" }],
       "pre": ["EDDF"],
       "type": "APP",
       "frequency": "120.805",
       "callsign": "Langen Radar"
     },
-    "FAS": {
+    "DFAS": {
       "colours": [{ "hex": "#227c85" }],
       "pre": ["EDDF"],
       "type": "APP",
       "frequency": "125.355",
       "callsign": "Langen Radar"
     },
-    "FFN": {
+    "DFANT": {
       "colours": [{ "hex": "#cb8695" }],
       "pre": ["EDDF"],
       "type": "APP",
       "frequency": "127.280",
       "callsign": "Frankfurt Arrival"
     },
-    "FFS": {
+    "DFAST": {
       "colours": [{ "hex": "#7da5a1" }],
       "pre": ["EDDF"],
       "type": "APP",
       "frequency": "118.505",
       "callsign": "Frankfurt Arrival"
     },
-    "FDN": {
+    "DFDN": {
       "colours": [{ "hex": "#3ec1fe" }],
       "pre": ["EDDF"],
       "type": "DEP",
       "frequency": "120.155",
       "callsign": "Langen Radar"
     },
-    "FDS": {
+    "DFDS": {
       "colours": [{ "hex": "#fcb71d" }],
       "pre": ["EDDF"],
       "type": "DEP",
@@ -13688,7 +13669,7 @@
       "frequency": "135.350",
       "callsign": "Langen Radar"
     },
-    "DKF": {
+    "DKAT": {
       "colours": [{ "hex": "#055a5a" }],
       "pre": ["EDDK"],
       "type": "APP",
@@ -13709,7 +13690,7 @@
       "frequency": "128.555",
       "callsign": "Langen Radar"
     },
-    "DLF": {
+    "DLAT": {
       "colours": [{ "hex": "#06cc9c" }],
       "pre": ["EDDL"],
       "type": "APP",
@@ -13737,7 +13718,7 @@
       "frequency": "129.675",
       "callsign": "Langen Radar"
     },
-    "SF": {
+    "DSAT": {
       "colours": [{ "hex": "#23f6ac" }],
       "pre": ["EDDS"],
       "type": "APP",
@@ -13778,6 +13759,55 @@
       "type": "APP",
       "frequency": "125.225",
       "callsign": "Langen Radar"
+    },
+    "TADA": {
+      "colours": [{ "hex": "#343e40" }],
+      "pre": ["ETAD"],
+      "type": "APP",
+      "frequency": "129.475",
+      "callsign": "Spangdahlem GCA"
+    },
+    "TARA": {
+      "colours": [{ "hex": "#308446" }],
+      "pre": ["ETAR"],
+      "type": "APP",
+      "frequency": "124.280",
+      "callsign": "Ramstein GCA"
+    },
+    "THFA": {
+      "colours": [{ "hex": "#606e8c" }],
+      "pre": ["ETHF"],
+      "type": "APP",
+      "frequency": "120.865",
+      "callsign": "Fritzlar Radar"
+    },
+    "THNA": {
+      "colours": [{ "hex": "#0e294b" }],
+      "pre": ["ETHN"],
+      "type": "APP",
+      "frequency": "127.190",
+      "callsign": "Stetten Radar"
+    },
+    "TNGA": {
+      "colours": [{ "hex": "#bdecB6" }],
+      "pre": ["ETNG"],
+      "type": "APP",
+      "frequency": "123.730",
+      "callsign": "Frisbee Radar"
+    },
+    "TNNA": {
+      "colours": [{ "hex": "#922b3e" }],
+      "pre": ["ETNN"],
+      "type": "APP",
+      "frequency": "129.055",
+      "callsign": "Nörvenich Radar"
+    },
+    "TSBA": {
+      "colours": [{ "hex": "#4c514a" }],
+      "pre": ["ETSB"],
+      "type": "APP",
+      "frequency": "130.155",
+      "callsign": "Büchel Radar"
     },
 
     "INFO": {
@@ -13880,22 +13910,22 @@
       "callsign": "Frankfurt",
       "coord": [50.033333333333, 8.5705],
       "runways": ["25", "07"],
-      "topdown": ["FAS", "FAN", "GIN", "RUD", "DKB", "BAD", "KTG"]
+      "topdown": ["DFAS", "DFAN", "GIN", "RUD", "DKB", "BAD", "KTG"]
     },
     "EDDG": {
       "callsign": "Münster",
       "coord": [52.134666666667, 7.6848333333333],
-      "topdown": ["HMM", "PAD", "PADH", "MNS", "RHR"]
+      "topdown": ["HMM", "PAD", "PADH"]
     },
     "EDDK": {
       "callsign": "Köln/Bonn",
       "coord": [50.866, 7.1426666666667],
-      "topdown": ["DKF", "DKA", "NOR", "PADH", "RHR"]
+      "topdown": ["DKAT", "DKA", "NOR", "PADH"]
     },
     "EDDL": {
       "callsign": "Düsseldorf",
       "coord": [51.281, 6.7573333333333],
-      "topdown": ["DLF", "DLD", "BOT", "DLA", "PADH", "RHR"]
+      "topdown": ["DLAT", "DLD", "BOT", "DLA", "PADH"]
     },
     "EDDS": {
       "callsign": "Stuttgart",
@@ -13915,22 +13945,22 @@
     "EDLN": {
       "callsign": "Mönchengladbach",
       "coord": [51.230333333333, 6.5045],
-      "topdown": ["DLF", "DLA", "DLD", "BOT", "PADH", "RHR"]
+      "topdown": ["DLAT", "DLA", "DLD", "BOT", "PADH"]
     },
     "EDLP": {
       "callsign": "Paderborn",
       "coord": [51.614166666667, 8.6163333333333],
-      "topdown": ["PADL", "HMML", "PADH", "MNS", "RHR"]
+      "topdown": ["PADL", "HMML", "PADH"]
     },
     "EDLV": {
       "callsign": "Niederrhein",
       "coord": [51.602333333333, 6.1421666666667],
-      "topdown": ["BOT", "DLD", "DLA", "DLF", "PADH", "RHR"]
+      "topdown": ["BOT", "DLD", "DLA", "DLAT", "PADH"]
     },
     "EDLW": {
       "callsign": "Dortmund",
       "coord": [51.518333333333, 7.6121666666667],
-      "topdown": ["PADL", "HMML", "PADH", "MNS", "RHR"]
+      "topdown": ["PADL", "HMML", "PADH"]
     },
     "EDSB": {
       "callsign": "Baden",
@@ -14062,7 +14092,8 @@
     "EDCW": { "callsign": "Wismar", "coord": ["53.916667", "11.5"] },
     "EDCX": { "callsign": "Purkshof", "coord": ["54.160882", "12.248418"] },
     "EDCY": { "callsign": "Spremberg-Welzow", "coord": ["51.583333", "14.133333"] },
-    "EDDR": { "callsign": "Saarbrucken", "coord": ["49.214444", "7.109444"] },
+    "EDDR": { "callsign": "Saarbrücken", "coord": ["49.214444", "7.109444"],
+      "topdown": ["PFA", "EIF", "RUD", "GIN", "KTG"] },
     "EDEB": { "callsign": "Bad Langensalza", "coord": ["51.129183", "10.621664"] },
     "EDEF": { "callsign": "Babenhausen", "coord": ["49.952883", "8.969258"] },
     "EDEG": { "callsign": "Gotha-Ost", "coord": ["50.970556", "10.728056"] },
@@ -14088,7 +14119,8 @@
     "EDFN": { "callsign": "Marburg-Schonstadt", "coord": ["50.866667", "8.816667"] },
     "EDFO": { "callsign": "Michelstadt", "coord": ["49.678", "8.973833"] },
     "EDFP": { "callsign": "Ober-Moerlen", "coord": ["50.361867", "8.710659"] },
-    "EDFQ": { "callsign": "Allendorf", "coord": ["51.035333", "8.680833"] },
+    "EDFQ": { "callsign": "Allendorf", "coord": ["51.035333", "8.680833"],
+      "topdown": ["GIN", "RUD", "KTG"] },
     "EDFR": { "callsign": "Rothenburg o. d. Tauber", "coord": ["49.383333", "10.216667"] },
     "EDFS": { "callsign": "Schweinfurt-Sued", "coord": ["50.010526", "10.251273"] },
     "EDFT": { "callsign": "Lauterbach", "coord": ["50.683222", "9.410276"] },
@@ -14110,7 +14142,8 @@
     "EDGP": { "callsign": "Oppenheim", "coord": ["49.841", "8.375833"] },
     "EDGQ": { "callsign": "Schameder", "coord": ["51.000128", "8.306823"] },
     "EDGR": { "callsign": "Giessen-Reiskirchen", "coord": ["50.566845", "8.8698"] },
-    "EDGS": { "callsign": "Siegerland", "coord": ["50.875", "8.083333"] },
+    "EDGS": { "callsign": "Siegerland", "coord": ["50.875", "8.083333"],
+      "topdown": ["SIG", "TAU", "GIN", "RUD", "KTG"] },
     "EDGT": { "callsign": "Bottenhorn", "coord": ["50.795205", "8.458514"] },
     "EDGU": { "callsign": "Unterschuepf", "coord": ["49.515578", "9.66831"] },
     "EDGW": { "callsign": "Wolfhagen \"Graner Berg\"", "coord": ["51.30704", "9.175305"] },
@@ -14264,7 +14297,8 @@
     "EDQD": { "callsign": "Bayreuth", "coord": ["49.98306", "11.63306"] },
     "EDQE": { "callsign": "Burg Feuerstein", "coord": ["49.794303", "11.132417"] },
     "EDQF": { "callsign": "Ansbach-Petersdorf", "coord": ["49.366667", "10.666667"] },
-    "EDQG": { "callsign": "Giebelstadt", "coord": ["49.648167", "9.9665"] },
+    "EDQG": { "callsign": "Giebelstadt", "coord": ["49.648167", "9.9665"],
+      "topdown": ["THNA", "DKB", "KTG", "BAD"] },
     "EDQH": { "callsign": "Herzogenaurach", "coord": ["49.5825", "10.878"] },
     "EDQI": { "callsign": "Lauf-Lillinghof", "coord": ["49.604746", "11.283908"] },
     "EDQK": { "callsign": "Kulmbach", "coord": ["50.133333", "11.466667"] },
@@ -14300,7 +14334,8 @@
     "EDRW": { "callsign": "Dierdorf-Wienau", "coord": ["50.566285", "7.653864"] },
     "EDRX": { "callsign": "Neunkirchen-Bexbach", "coord": ["49.335306", "7.265874"] },
     "EDRY": { "callsign": "Speyer", "coord": ["49.302775", "8.451194"] },
-    "EDRZ": { "callsign": "Zweibrucken", "coord": ["49.21", "7.401667"] },
+    "EDRZ": { "callsign": "Zweibrücken", "coord": ["49.21", "7.401667"],
+      "topdown": ["PFA", "EIF", "RUD", "GIN", "KTG"] },
     "EDSA": { "callsign": "Albstadt-Degerfeld", "coord": ["48.249667", "9.060333"] },
     "EDSE": { "callsign": "Goeppingen-Bezgenriet", "coord": ["48.658333", "9.625"] },
     "EDSF": { "callsign": "Huetten-Hotzenwald", "coord": ["47.633981", "7.937261"] },
@@ -14319,13 +14354,15 @@
     "EDSZ": { "callsign": "Rottweil-Zepfenhan", "coord": ["48.186553", "8.721245"] },
     "EDTB": { "callsign": "Baden-Oos", "coord": ["48.79176", "8.186586"] },
     "EDTC": { "callsign": "Bruchsal", "coord": ["49.135058", "8.563473"] },
-    "EDTD": { "callsign": "Donaueschingen-Villingen", "coord": ["47.9735", "8.522167"] },
+    "EDTD": { "callsign": "Donaueschingen", "coord": ["47.9735", "8.522167"],
+      "topdown": ["ls/ZA", "ls/ZAW", "ls/SZE", "ls/SZS", "ls/SZ", "ls/SC", "ls/ZF"] },
     "EDTE": { "callsign": "Eutingen Im Gaeu", "coord": ["48.4855", "8.778167"] },
     "EDTF": { "callsign": "Freiburg i. Br.", "coord": ["48.022667", "7.832583"] },
     "EDTG": { "callsign": "Bremgarten", "coord": ["47.903241", "7.61779"] },
     "EDTH": { "callsign": "Heubach", "coord": ["48.8", "9.933333"] },
     "EDTK": { "callsign": "Karlsruhe-Forchheim", "coord": ["48.979667", "8.331167"] },
-    "EDTM": { "callsign": "Mengen-Hohentengen", "coord": ["48.053833", "9.372833"] },
+    "EDTM": { "callsign": "Mengen", "coord": ["48.053833", "9.372833"],
+      "topdown": ["ls/ARFA", "ls/ZA", "ls/SZE", "ls/SZS", "ls/SZ", "ls/SC", "ZUG", "TRU", "RDG"] },
     "EDTN": { "callsign": "Nabern/Teck", "coord": ["48.612623", "9.477242"] },
     "EDTO": { "callsign": "Offenburg", "coord": ["48.44985", "7.924684"] },
     "EDTP": { "callsign": "Pfullendorf", "coord": ["47.916667", "9.25"] },
@@ -14335,7 +14372,8 @@
     "EDTU": { "callsign": "Saulgau", "coord": ["48.029355", "9.50725"] },
     "EDTW": { "callsign": "Winzeln-Schramberg", "coord": ["48.279167", "8.428333"] },
     "EDTX": { "callsign": "Sch.Hall-Weckrieden", "coord": ["49.125", "9.783333"] },
-    "EDTY": { "callsign": "Sch.Hall-Hessental", "coord": ["49.12", "9.778333"] },
+    "EDTY": { "callsign": "Schwäbisch Hall", "coord": ["49.12", "9.778333"],
+      "topdown": ["STG", "REU", "BAD", "DKB", "KTG"] },
     "EDTZ": { "callsign": "Konstanz", "coord": ["47.68306", "9.18306"] },
     "EDUA": { "callsign": "Stechow-Ferchesar", "coord": ["52.650697", "12.487837"] },
     "EDUF": { "callsign": "Falkenberg-Loennewitz", "coord": ["51.547806", "13.228139"] },
@@ -14409,33 +14447,43 @@
     "EDXU": { "callsign": "Huettenbusch", "coord": ["53.286262", "8.947278"] },
     "EDXY": { "callsign": "Wyk (Foehr)", "coord": ["54.683333", "8.533333"] },
     "EDXZ": { "callsign": "Kuehrstedt-Bederkesa", "coord": ["53.568056", "8.78935"] },
-    "ETAD": { "callsign": "Spangdahlem", "coord": ["49.972667", "6.6925"] },
-    "ETAR": { "callsign": "Ramstein", "coord": ["49.436667", "7.6"] },
-    "ETEB": { "callsign": "Ansbach", "coord": ["49.308167", "10.638667"] },
+    "ETAD": { "callsign": "Spangdahlem", "coord": ["49.972667", "6.6925"],
+      "topdown": ["TADA", "EIF", "RUD", "GIN", "KTG"] },
+    "ETAR": { "callsign": "Ramstein", "coord": ["49.436667", "7.6"],
+      "topdown": ["TARA", "PFA", "EIF", "RUD", "GIN", "KTG"] },
+    "ETEB": { "callsign": "Ansbach", "coord": ["49.308167", "10.638667"],
+      "topdown": ["DKB", "KTG", "BAD"] },
     "ETEK": { "callsign": "Baumholder", "coord": ["49.6515", "7.307167"] },
     "ETHA": { "callsign": "Altenstadt", "coord": ["47.8355", "10.871333"] },
     "ETHB": { "callsign": "Buckeburg", "coord": ["52.2785", "9.082167"] },
     "ETHC": { "callsign": "Celle", "coord": ["52.596333", "10.025833"] },
-    "ETHF": { "callsign": "Fritzlar", "coord": ["51.1145", "9.285833"] },
+    "ETHF": { "callsign": "Fritzlar", "coord": ["51.1145", "9.285833"],
+      "topdown": ["THFA", "HEF", "GIN", "RUD", "KTG"] },
     "ETHL": { "callsign": "Laupheim", "coord": ["48.220108", "9.910208"] },
-    "ETHN": { "callsign": "Niederstetten", "coord": ["49.393333", "9.96"] },
+    "ETHN": { "callsign": "Stetten", "coord": ["49.393333", "9.96"],
+      "topdown": ["THNA", "DKB", "KTG", "BAD"] },
     "ETHS": { "callsign": "Fassberg", "coord": ["52.919333", "10.183833"] },
     "ETIC": { "callsign": "Grafenwohr", "coord": ["49.69948", "11.941217"] },
     "ETIH": { "callsign": "Hohenfels", "coord": ["49.2165", "11.836167"] },
-    "ETIK": { "callsign": "Illesheim", "coord": ["49.473833", "10.387833"] },
+    "ETIK": { "callsign": "Illesheim", "coord": ["49.473833", "10.387833"],
+      "topdown": ["DKB", "KTG", "BAD"] },
     "ETMN": { "callsign": "Nordholz", "coord": ["53.768333", "8.658333"] },
     "ETND": { "callsign": "Diepholz", "coord": ["52.583333", "8.35"] },
-    "ETNG": { "callsign": "Geilenkirchen", "coord": ["50.960836", "6.041944"] },
+    "ETNG": { "callsign": "Geilenkirchen", "coord": ["50.960836", "6.041944"],
+      "topdown": ["TNGA", "BOT", "DLD", "DLA", "DLAT", "PADH"] },
     "ETNH": { "callsign": "Hohn", "coord": ["54.313333", "9.54"] },
     "ETNJ": { "callsign": "Jever", "coord": ["53.533333", "7.883333"] },
-    "ETNN": { "callsign": "Norvenich", "coord": ["50.831167", "6.658167"] },
+    "ETNN": { "callsign": "Nörvenich", "coord": ["50.831167", "6.658167"],
+      "topdown": ["TNNA", "DKA", "NOR", "PADH"] },
     "ETNS": { "callsign": "Schleswig", "coord": ["54.459333", "9.516333"] },
     "ETNT": { "callsign": "Wittmundhafen", "coord": ["53.547833", "7.667333"] },
     "ETNW": { "callsign": "Wunstorf", "coord": ["52.454333", "9.423"] },
     "ETOI": { "callsign": "Vilseck Aaf", "coord": ["49.634033", "11.767861"] },
-    "ETOU": { "callsign": "Wiesbaden", "coord": ["50.049833", "8.3255"] },
+    "ETOU": { "callsign": "Wiesbaden", "coord": ["50.049833", "8.3255"],
+      "topdown": ["DFDN", "DFDS", "DFAN", "DFAS", "GIN", "RUD", "DKB", "BAD", "KTG"] },
     "ETSA": { "callsign": "Landsberg", "coord": ["48.070556", "10.906111"] },
-    "ETSB": { "callsign": "Buchel", "coord": ["50.173889", "7.063333"] },
+    "ETSB": { "callsign": "Büchel", "coord": ["50.173889", "7.063333"],
+      "topdown": ["TSBA", "EIF", "RUD", "GIN", "KTG"] },
     "ETSF": { "callsign": "Furstenfeldbruck", "coord": ["48.204713", "11.267825"] },
     "ETSH": { "callsign": "Holzdorf", "coord": ["51.767833", "13.167667"] },
     "ETSI": { "callsign": "Ingolstadt-Manching", "coord": ["48.715", "11.503333"] },

--- a/data/ed.json
+++ b/data/ed.json
@@ -9005,6 +9005,7 @@
         "SH",
         "SL",
 	"YY-BB",
+	"EMS",
         "DST",
         "EIDW",
         "WWC"
@@ -9064,6 +9065,7 @@
         "SL",
         "SH",
 	"YY-BB",
+	"EMS",
         "DST",
         "EIDW",
         "WWC"
@@ -9237,7 +9239,7 @@
       "owner": [
         "RL",
         "RH",
-	"LL",
+	"ML",
 	"MH",
         "PADH"
       ],
@@ -12792,7 +12794,7 @@
       "group": "EDYY",
       "uid": "SH",
       "owner": [
-        "SL",
+        "SH",
         "CH",
 	"MH",
 	"SL",
@@ -12877,7 +12879,7 @@
     "EDWW": { "name": "Bremen" },
     "EDMM": { "name": "München" },
     "APP": { "name": "Approach" },
-    "EDUU": { "name": "Rhein (Karlsruhe)" },
+    "EDUU": { "name": "Rhein" },
     "EDYY": { "name": "Maastricht" },
     "EDWWMIL": { "name": "Bremen (Military)" },
     "EDMMMIL": { "name": "München (Military)" },


### PR DESCRIPTION
- defined military APP positions within EDGG for correct topdown hierarchy at military airports
- new ownership hierarchies for MUAC Hanover group, also introduced vertical split positions for RHR and MNS
- fixed missing ownership hierarchies for various IFR capable airports within EDGG
- fixed outdated boundaries for DKB, HAB, and KNG (changed with AIRAC2408)
- some clerical changes

--------------------

/schedule 2024-12-26