### PR TITLE
Fixed incorrect ownership EDWW ALR sector

### DIFF
--- a/data/ed.json
+++ b/data/ed.json
@@ -9835,7 +9835,7 @@
       "id": "Aller",
       "group": "EDWW",
       "uid": "ALR",
-      "owner": ["ALR", "EIDW", "WWC"],
+      "owner": ["ALR", "HEI", "EIDW", "WWC"],
       "sectors": [
         {
           "max": 244,


### PR DESCRIPTION
Sector HEI was missing in the definition of sector ownership for EDWW sector Aller. Can be merged ASAP.