### PR TITLE
Update ownership in LFXX sectors

### DIFF
--- a/data/lf.json
+++ b/data/lf.json
@@ -21669,7 +21669,8 @@
       "group": "LFEE",
       "owner": [
         "KD",
-        "EE"
+        "EE",
+        "PAR"
       ],
       "sectors": [
         {

--- a/data/lf.json
+++ b/data/lf.json
@@ -3477,7 +3477,7 @@
       "id": "W1",
       "group": "LFMM",
       "owner": [
-        "MWU",
+        "MMW",
         "MRAW",
         "MM"
       ],

--- a/data/lf.json
+++ b/data/lf.json
@@ -62296,7 +62296,7 @@
     },
     "LLA": {
       "callsign": "Lyon Approach",
-      "frequency": "120.230",
+      "frequency": "131.315",
       "type": "APP",
       "pre": [
         "LFLL"

--- a/data/lf.json
+++ b/data/lf.json
@@ -47646,6 +47646,7 @@
       "owner": [
         "RZ",
         "RSI",
+        "RSA",
         "RR"
       ],
       "sectors": [
@@ -66531,6 +66532,7 @@
       ],
       "topdown": [
         "RSI",
+        "RSA",
         "RR"
       ]
     },


### PR DESCRIPTION
- Update ownership in LFMM W1 sector (FL195-FL245):
  - Before: `MMU` - `LFMM_U_CTR`
  - After: `MMW` - `LFMM_W_CTR`
- Add `PAR` - `PAR_CTR` as owner of sector LFEE KD1 (FL355-FL385)
- Add `RSA` - `LFRS_APP` as owner of LFRZ CTR
- Update Lyon Approach `LFLL_APP` frequency
