### PR TITLE
Update LHCC frequencies to AIRAC 2512

### DIFF
--- a/data/lh.json
+++ b/data/lh.json
@@ -3025,11 +3025,11 @@
 		"TWR":{"name":"Tower"}
 	},
 	"positions":{
-		"LHBP_APP": {"colours": [{"hex": "#DFFF00"}], "pre": ["LHBP"], "type": "APP", "frequency": "122.975", "callsign": "Budapest Approach"},
+		"LHBP_APP": {"colours": [{"hex": "#DFFF00"}], "pre": ["LHBP"], "type": "APP", "frequency": "122.980", "callsign": "Budapest Approach"},
 		"LHBP_U_APP": {"colours": [{"hex": "#ffbf00"}], "pre": ["LHBP"], "type": "APP", "frequency": "123.850", "callsign": "Budapest Approach"},
-		"LHBP_TWR": {"colours": [{"hex": "#6495ed"}], "pre": ["LHBP"], "type": "TWR", "frequency": "118.100", "callsign": "Budapest Tower"},
-		"LHCC_W_CTR": {"colours": [{"hex": "#c7b192"}], "pre": ["LHCC"], "type": "CTR", "frequency": "133.200", "callsign": "Budapest Control"},
-		"LHCC_CTR": {"colours": [{"hex": "#247513"}], "pre": ["LHCC"], "type": "CTR", "frequency": "120.375", "callsign": "Budapest Control"},
+		"LHBP_TWR": {"colours": [{"hex": "#6495ed"}], "pre": ["LHBP"], "type": "TWR", "frequency": "118.715", "callsign": "Budapest Tower"},
+		"LHCC_W_CTR": {"colours": [{"hex": "#c7b192"}], "pre": ["LHCC"], "type": "CTR", "frequency": "133.205", "callsign": "Budapest Control"},
+		"LHCC_CTR": {"colours": [{"hex": "#247513"}], "pre": ["LHCC"], "type": "CTR", "frequency": "120.380", "callsign": "Budapest Control"},
 		"LHCC_2_CTR": {"colours": [{"hex": "#49836c"}], "pre": ["LHCC"], "type": "CTR", "frequency": "135.200", "callsign": "Budapest Control"},
 		"LHCC_1_CTR": {"colours": [{"hex": "#DFFF00"}], "pre": ["LHCC"], "type": "CTR", "frequency": "135.550", "callsign": "Budapest Control"},
 		"LHCC_N_CTR": {"colours": [{"hex": "#DFFF00"}], "pre": ["LHCC"], "type": "CTR", "frequency": "118.725", "callsign": "Budapest Control"},


### PR DESCRIPTION
Several frequencies has been updated to 8.33khz and therefore has been changed in LHCC in AIRAC 2512

https://ais-en.hungarocontrol.hu/aip/2025-11-27/
https://storage.hungarocontrol.hu/media/1346/LH_Circ_2025_A_008_en.pdf

LHCC: https://ais-en.hungarocontrol.hu/aip/2025-11-27/2025-11-27-AIRAC/html/eAIP/LH-ENR-2.1-en-HU.html?amdt=show#ENR212025100812121109000000

LHBP: https://ais-en.hungarocontrol.hu/aip/2025-11-27/2025-11-27-AIRAC/html/eAIP/LH-AD-2.LHBP-en-HU.html?amdt=show#Aerodrome2025092213421006810000

The other frequencies for LHBP and CTR also seem wrong, they cannot be found in the AIP, but I cannot find an exact guide on what changed to what, so I guess they were changed long time ago.