### PR TITLE
Update owner list for ESOS 7-3

### DIFF
--- a/data/es.json
+++ b/data/es.json
@@ -570,7 +570,7 @@
         {
           "id": "ESOS 7-3",
           "group": "ESOS",
-          "owner": ["S7", "S1", "S9", "S3", "AA", "MW", "M7", "M2"],
+          "owner": ["S7", "S1", "S9", "S3", "AA"],
           "sectors": [
             {
               "min": 105,


### PR DESCRIPTION
Removed 'M7' and 'M2' from the owner list for ESOS 7-3.