### PR TITLE
LOVV: Fix gap in displayed coverage due to stations not covering top-down

### DIFF
--- a/data/lo.json
+++ b/data/lo.json
@@ -3834,7 +3834,21 @@
     {
       "id": "Klagenfurt",
       "group": "LOWK",
-      "owner": ["AK", "AGK"],
+      "owner": [
+        "AK",
+        "AGK",
+        "VCL",
+        "VCW",
+        "VCWC",
+        "VCS",
+        "VCB",
+        "VCBC",
+        "VC",
+        "VCC",
+        "VCWU",
+        "VCSU",
+        "VCBU"
+      ],
       "sectors": [
         {
           "min": 125,


### PR DESCRIPTION
Only effected a small part of the Klagenfurt TMA.