### PR TITLE
Fixed LFMM_U_CTR missing sectors

### DIFF
--- a/data/lf.json
+++ b/data/lf.json
@@ -3844,6 +3844,7 @@
       "owner": [
         "MMW",
         "MWU",
+        "MUU",
         "MRAW",
         "MM"
       ],
@@ -3914,6 +3915,7 @@
       "owner": [
         "MMW",
         "MWU",
+        "MUU",
         "MRAW",
         "MM"
       ],
@@ -3984,6 +3986,7 @@
       "owner": [
         "MMW",
         "MWU",
+        "MUU",
         "MRAW",
         "MM"
       ],
@@ -4054,6 +4057,7 @@
       "owner": [
         "MMW",
         "MWU",
+        "MUU",
         "MRAW",
         "MM"
       ],
@@ -12115,6 +12119,7 @@
       "owner": [
         "MMA",
         "MEU",
+        "MUU",
         "MRAE",
         "MM"
       ],
@@ -12217,6 +12222,7 @@
       "owner": [
         "MMA",
         "MEU",
+        "MUU",
         "MRAE",
         "MM"
       ],
@@ -12319,6 +12325,7 @@
       "owner": [
         "MMA",
         "MEU",
+        "MUU",
         "MRAE",
         "MM"
       ],
@@ -12421,6 +12428,7 @@
       "owner": [
         "MMA",
         "MEU",
+        "MUU",
         "MRAE",
         "MM"
       ],
@@ -12523,6 +12531,7 @@
       "owner": [
         "MMA",
         "MEU",
+        "MUU",
         "MRAE",
         "MM"
       ],


### PR DESCRIPTION
Added "MUU" as owner to all LFMM A UAC and LFMM W UAC sectors